### PR TITLE
rename StructInit to StructExpression: which much better explains wha…

### DIFF
--- a/src/compiler/ast/ast.rs
+++ b/src/compiler/ast/ast.rs
@@ -224,7 +224,7 @@ impl CompilerNode {
                 )
             }
             StructDef(..) => panic!("StructDef Unimplemented"),
-            StructInit(meta, struct_name, fields) => {
+            StructExpression(meta, struct_name, fields) => {
                 let (meta, mut nlayout) = Scope::local_from(meta, struct_table, layout);
                 let mut nfields = vec![];
                 for (fname, fvalue) in fields.iter() {
@@ -232,7 +232,7 @@ impl CompilerNode {
                     nlayout = no;
                     nfields.push((fname.clone(), nfv));
                 }
-                (StructInit(meta, struct_name.clone(), nfields), nlayout)
+                (StructExpression(meta, struct_name.clone(), nfields), nlayout)
             }
         }
     }

--- a/src/compiler/ast/stringpool.rs
+++ b/src/compiler/ast/stringpool.rs
@@ -123,7 +123,7 @@ impl StringPool {
                 }
             }
             StructDef(..) => {}
-            StructInit(_, _, fields) => {
+            StructExpression(_, _, fields) => {
                 for (_, f) in fields.iter() {
                     self.extract_from(f);
                 }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -612,7 +612,7 @@ impl<'a> Compiler<'a> {
                     call @{fn_name};
                 }};
             }
-            Ast::StructInit(_, struct_name, fields) => {
+            Ast::StructExpression(_, struct_name, fields) => {
                 let asm = self.init_struct(current_func, struct_name, fields, 0, true)?;
                 assembly! {(code){
                     {{asm}}
@@ -741,7 +741,7 @@ impl<'a> Compiler<'a> {
         let mut code = vec![];
 
         match fvalue {
-            Ast::StructInit(_, substruct_name, substruct_values) => {
+            Ast::StructExpression(_, substruct_name, substruct_values) => {
                 let asm = self.init_struct(
                     current_func,
                     substruct_name,

--- a/src/semantics/semanticnode.rs
+++ b/src/semantics/semanticnode.rs
@@ -159,13 +159,13 @@ impl SemanticNode {
                 name.clone(),
                 fields.clone(),
             ))),
-            StructInit(l, name, fields) => {
+            StructExpression(l, name, fields) => {
                 let mut nfields = vec![];
                 for (fname, fvalue) in fields.iter() {
                     let fvalue2 = SemanticNode::from_parser_ast(fvalue)?;
                     nfields.push((fname.clone(), *fvalue2));
                 }
-                Ok(Box::new(StructInit(sm_from(*l), name.clone(), nfields)))
+                Ok(Box::new(StructExpression(sm_from(*l), name.clone(), nfields)))
             }
         }
     }

--- a/src/semantics/type_checker.rs
+++ b/src/semantics/type_checker.rs
@@ -365,7 +365,7 @@ pub mod checker {
                     let mut pty = vec![];
                     for param in params.iter_mut() {
                         match param {
-                            StructInit(..) => return Err(format!("Cannot pass struct expression as function parameter (future feature)")),
+                            StructExpression(..) => return Err(format!("Cannot pass struct expression as function parameter (future feature)")),
                             _ => (),
                         }
                         let ty = self.traverse(param, current_func, sym)?;
@@ -506,7 +506,7 @@ pub mod checker {
                     }
                     Ok(Unit)
                 }
-                StructInit(meta, struct_name, params) => {
+                StructExpression(meta, struct_name, params) => {
                     // Validate the types in the initialization parameters
                     // match their respective members in the struct
                     let struct_def = self.lookup(sym, &struct_name)?.ty.clone();

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -125,7 +125,7 @@ pub enum Ast<I> {
         structs: Vec<Ast<I>>,
     },
     StructDef(I, String, Vec<(String, Type)>),
-    StructInit(I, String, Vec<(String, Ast<I>)>),
+    StructExpression(I, String, Vec<(String, Ast<I>)>),
 }
 
 impl<I> Ast<I> {
@@ -163,7 +163,7 @@ impl<I> Ast<I> {
 
             Module { .. } => "module".into(),
             StructDef(_, name, ..) => format!("definition of struct {}", name),
-            StructInit(_, name, ..) => format!("intialization for struct {}", name),
+            StructExpression(_, name, ..) => format!("intialization for struct {}", name),
         }
     }
 
@@ -195,7 +195,7 @@ impl<I> Ast<I> {
             | RoutineCall(m, ..)
             | Module { meta: m, .. }
             | StructDef(m, ..) => m,
-            StructInit(m, ..) => m,
+            StructExpression(m, ..) => m,
         }
     }
 

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -611,7 +611,7 @@ fn struct_expression(stream: &mut TokenStream) -> PResult {
             "L{}: Expected valid field assignments in struct expression",
             line
         ))?;
-        Ok(Some(Ast::StructInit(line, struct_name, fields)))
+        Ok(Some(Ast::StructExpression(line, struct_name, fields)))
     } else {
         Ok(None)
     }
@@ -1435,14 +1435,14 @@ pub mod tests {
     #[test]
     fn parse_struct_init() {
         for (text, expected) in vec![
-            ("MyStruct{}", Ast::StructInit(1, "MyStruct".into(), vec![])),
+            ("MyStruct{}", Ast::StructExpression(1, "MyStruct".into(), vec![])),
             (
                 "MyStruct{x: 5}",
-                Ast::StructInit(1, "MyStruct".into(), vec![("x".into(), Ast::Integer(1, 5))]),
+                Ast::StructExpression(1, "MyStruct".into(), vec![("x".into(), Ast::Integer(1, 5))]),
             ),
             (
                 "MyStruct{x: 5, y: false}",
-                Ast::StructInit(
+                Ast::StructExpression(
                     1,
                     "MyStruct".into(),
                     vec![
@@ -1453,14 +1453,14 @@ pub mod tests {
             ),
             (
                 "MyStruct{x: 5, y: MyStruct2{z:3}}",
-                Ast::StructInit(
+                Ast::StructExpression(
                     1,
                     "MyStruct".into(),
                     vec![
                         ("x".into(), Ast::Integer(1, 5)),
                         (
                             "y".into(),
-                            Ast::StructInit(
+                            Ast::StructExpression(
                                 1,
                                 "MyStruct2".into(),
                                 vec![("z".into(), Ast::Integer(1, 3))],


### PR DESCRIPTION
…t it is syntactically