### PR TITLE
event supports writable

### DIFF
--- a/src/compiler/lexer/lexer.rs
+++ b/src/compiler/lexer/lexer.rs
@@ -263,7 +263,7 @@ impl<'a> Lexer<'a> {
             }
 
             let (_, span) = branch.merge().unwrap();
-            self.logger.write(Event::<LexerError> {
+            self.logger.write(Event::<_, LexerError> {
                 stage: "lexer",
                 input: span,
                 msg: Ok("Line Comment"),
@@ -279,7 +279,7 @@ impl<'a> Lexer<'a> {
             }
 
             let (_, span) = branch.merge().unwrap();
-            self.logger.write(Event::<LexerError> {
+            self.logger.write(Event::<_, LexerError> {
                 stage: "lexer",
                 input: span,
                 msg: Ok("Block Comment"),
@@ -325,7 +325,7 @@ impl<'a> Lexer<'a> {
                                 LexerError::InvalidEscapeSequence(c)
                             )
                             .map_err(|err| {
-                                self.logger.write(Event {
+                                self.logger.write(Event::<&str, _> {
                                     stage: "lexer",
                                     input: err.span(),
                                     msg: Err(&err),
@@ -339,7 +339,7 @@ impl<'a> Lexer<'a> {
                                 LexerError::ExpectedEscapeCharacter
                             )
                             .map_err(|err| {
-                                self.logger.write(Event {
+                                self.logger.write(Event::<&str, _> {
                                     stage: "lexer",
                                     input: err.span(),
                                     msg: Err(&err),
@@ -364,7 +364,7 @@ impl<'a> Lexer<'a> {
         }
         .map(|ok| {
             ok.as_ref().map(|token| {
-                self.logger.write(Event::<LexerError> {
+                self.logger.write(Event::<_, LexerError> {
                     stage: "lexer",
                     input: token.span,
                     msg: Ok("String"),
@@ -412,7 +412,7 @@ impl<'a> Lexer<'a> {
         }
         .map(|ok| {
             ok.as_ref().map(|token| {
-                self.logger.write(Event::<LexerError> {
+                self.logger.write(Event::<_, LexerError> {
                     stage: "lexer",
                     input: token.span,
                     msg: Ok("Integer"),
@@ -421,7 +421,7 @@ impl<'a> Lexer<'a> {
             ok
         })
         .map_err(|err| {
-            self.logger.write(Event {
+            self.logger.write(Event::<&str, _> {
                 stage: "lexer",
                 input: err.span(),
                 msg: Err(&err),
@@ -499,7 +499,7 @@ impl<'a> Lexer<'a> {
         }))
         .map(|ok| {
             ok.as_ref().map(|token| {
-                self.logger.write(Event::<LexerError> {
+                self.logger.write(Event::<_, LexerError> {
                     stage: "lexer",
                     input: token.span,
                     msg: Ok("Operator"),
@@ -532,7 +532,7 @@ impl<'a> Lexer<'a> {
         }
         .map(|ok| {
             ok.as_ref().map(|token| {
-                self.logger.write(Event::<LexerError> {
+                self.logger.write(Event::<_, LexerError> {
                     stage: "lexer",
                     input: token.span,
                     msg: Ok("Identifier"),
@@ -559,7 +559,7 @@ impl<'a> Lexer<'a> {
                 }
                 .map(|ok| {
                     ok.as_ref().map(|token| {
-                        self.logger.write(Event::<LexerError> {
+                        self.logger.write(Event::<_, LexerError> {
                             stage: "lexer",
                             input: token.span,
                             msg: Ok("Boolean"),
@@ -611,7 +611,7 @@ impl<'a> Lexer<'a> {
         })
         .map(|ok| {
             ok.as_ref().map(|token| {
-                self.logger.write(Event::<LexerError> {
+                self.logger.write(Event::<_, LexerError> {
                     stage: "lexer",
                     input: token.span,
                     msg: Ok("Keyword"),
@@ -651,7 +651,7 @@ impl<'a> Lexer<'a> {
         })
         .map(|ok| {
             ok.as_ref().map(|token| {
-                self.logger.write(Event::<LexerError> {
+                self.logger.write(Event::<_, LexerError> {
                     stage: "lexer",
                     input: token.span,
                     msg: Ok("Primitive"),

--- a/src/compiler/parser/tokenstream.rs
+++ b/src/compiler/parser/tokenstream.rs
@@ -84,7 +84,7 @@ impl<'a> TokenStream<'a> {
             }
         }
         .map_err(|err| {
-            self.logger.write(Event::<ParserError> {
+            self.logger.write(Event::<&str, ParserError> {
                 stage: "parser",
                 input: err.span(),
                 msg: Err(&err),

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, marker::PhantomData};
 
 use config::TracingConfig;
 
-use crate::compiler::{diagnostics::Writer, SourceMap};
+use crate::compiler::{
+    diagnostics::{Writable, Writer},
+    SourceMap,
+};
 
 pub mod config;
 
@@ -38,8 +41,10 @@ impl<'a> Writer for ConsoleWriter<'a> {
         };
     }
 
-    fn write_str(&self, label: &str, s: &str) {
-        print!("{}: \"{}\", ", label, s);
+    fn write_field(&self, label: &str, s: &dyn Writable) {
+        print!("{}: ", label);
+        s.write(self);
+        print!(", ");
     }
 
     fn start_event(&self) {
@@ -48,6 +53,10 @@ impl<'a> Writer for ConsoleWriter<'a> {
 
     fn stop_event(&self) {
         print!("}}\n");
+    }
+
+    fn write_str(&self, s: &str) {
+        print!("\"{}\", ", s);
     }
 }
 


### PR DESCRIPTION
Closes #197 

This updates the `Event` type to be able to take any `Writable` value for the success variant of result. Doing this will allow values which contain internal representations, such as `StringId`, to be sent to the UI layer and formatted in a human readable way.