### PR TITLE
reduce all blocks of whitespace to a single space so that more code i…

### DIFF
--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -34,6 +34,8 @@ impl<'a> Writer for ConsoleWriter<'a> {
 
         // Get source code that the span covers
         let src = self.source_map.text_in_span(span).unwrap();
+
+        // Compress blocks of whitespace to a single space
         let src = src.split_ascii_whitespace().collect::<Vec<_>>().join(" ");
 
         let width = 20;


### PR DESCRIPTION
…s fit into the code snippet