### PR TITLE
Parent id migrate lexer

### DIFF
--- a/src/compiler/lexer/lexer.rs
+++ b/src/compiler/lexer/lexer.rs
@@ -189,6 +189,7 @@ impl<'a> Lexer<'a> {
         })
     }
 
+    /// Record a new lexer event
     fn record<'e>(&self, span: Span, result: Result<&'e str, &'e CompilerError<LexerError>>) {
         let evt = Event::new_with_result("lexer", span, result, self.event_stack.clone());
         self.logger.write(evt);


### PR DESCRIPTION
Migrate the Lexer stage to use the new parent event tracking system.  No event in the Lexer will currently have parents, but using a single system for all event recording will simplify the design of the system and reduce the likely hood of events being incorrectly or not correlated.